### PR TITLE
Fix mermaid diagram syntax errors

### DIFF
--- a/system-design-comprehensive.md
+++ b/system-design-comprehensive.md
@@ -40,7 +40,7 @@ flowchart LR
     User[Buyer / Visitor]
     Affiliate[Affiliate]
     Admin[Admin]
-    Pay[Payment Providers<br/>(Stripe, PayPal, PayHero/M-Pesa)]
+    Pay["Payment Providers\n(Stripe, PayPal, PayHero/M-Pesa)"]
     CF[(Cloudflare<br/>R2 + Images + CDN)]
     SEO[Search Engines]
     
@@ -261,7 +261,7 @@ erDiagram
     AFFILIATES ||--o{ AFFILIATE_CONVERSIONS : converts
     
     COMMISSIONS }o--|| ORDERS : from
-    COMMISSIONS }o--|| AFFILIATES : to
+    COMMISSIONS }o--|| AFFILIATES : "to"
     
     BLOG_POSTS }o--|| USERS : created_by
     CMS_PAGES }o--|| USERS : created_by


### PR DESCRIPTION
Fixes Mermaid diagram parsing errors to ensure correct rendering on GitHub.

The original diagrams failed to render due to unquoted parentheses in a flowchart node label and an unquoted single-word label in an ER diagram relationship, which caused syntax errors for the Mermaid parser.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c997307-25f1-45aa-b59e-065160ccc7df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c997307-25f1-45aa-b59e-065160ccc7df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

