### PR TITLE
Fix mermaid diagram syntax errors

### DIFF
--- a/system-design-comprehensive.md
+++ b/system-design-comprehensive.md
@@ -198,7 +198,7 @@ sequenceDiagram
 sequenceDiagram
   participant U as "User"
   participant FE as "Frontend"
-  participant AUTH as "Auth Provider (Supabase)"
+  participant AUTH as "Auth Provider"
   participant API as "Backend"
   participant DB as "Postgres"
 
@@ -1224,7 +1224,7 @@ flowchart LR
     Frontend[Next.js Frontend / SPA]
     API[Backend API Services]
     DB[(Primary Postgres DB)]
-    Auth[Auth Provider (Supabase/Auth Adapter)]
+    Auth["Auth Provider (Supabase/Auth Adapter)"]
     Queue[Job Queue / Workers]
   end
 
@@ -1260,7 +1260,7 @@ flowchart LR
   PaymentProvider --> Webhook["Payment Webhook → API"]
   Webhook --> OrderDB[(Orders, Payments)]
   Webhook --> License[License Issuance & Download Tokens]
-  License --> CloudR2[Cloudflare R2 (files)]
+  License --> CloudR2["Cloudflare R2 (files)"]
   User --> Account[User Account / Downloads Vault]
   Admin --> AdminConsole[Admin: CRUD Content & Products]
   AdminConsole --> CatalogDB


### PR DESCRIPTION
Fixes Mermaid diagram parsing errors by quoting labels and simplifying participant names.

The errors were caused by Mermaid's parser having trouble with unquoted parentheses in flowchart node labels and in sequence diagram participant declarations. Quoting the labels and simplifying the participant name resolves these syntax issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-05fb86b3-7707-4aa4-a306-731cc4960627">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05fb86b3-7707-4aa4-a306-731cc4960627">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

