### PR TITLE
Debug mermaid diagram syntax error

### DIFF
--- a/system-design-comprehensive.md
+++ b/system-design-comprehensive.md
@@ -207,10 +207,10 @@ sequenceDiagram
   AUTH-->>FE: Auth tokens (access + refresh)
   FE->>API: Exchange token for secure httpOnly cookie / session
   API->>DB: Upsert user row and create session row (device info)
-  API-->>FE: Session cookie set; return user profile
+  API-->>FE: Session cookie set, return user profile
   U->>FE: Perform protected action (download)
-  FE->>API: Uses cookie; API validates session vs DB
-  API->>DB: Session fresh check; enforce MFA requirement for critical ops
+  FE->>API: Uses cookie, API validates session vs DB
+  API->>DB: Session fresh check, enforce MFA requirement for critical ops
   API-->>FE: proceed / deny
 ```
 


### PR DESCRIPTION
Fixes Mermaid diagram syntax errors by replacing semicolons in message text with commas.

The original Mermaid sequence diagram failed to render due to semicolons within the message text of arrows. Mermaid interprets semicolons as statement separators, leading to parsing errors. Replacing them with commas resolves this issue, allowing the diagram to render correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-7725bea9-4ee8-4bda-a740-14ec01e01b71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7725bea9-4ee8-4bda-a740-14ec01e01b71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

